### PR TITLE
Allow secret key to be generated for user

### DIFF
--- a/e2e/auth.js
+++ b/e2e/auth.js
@@ -236,6 +236,14 @@ describe('auth', function() {
         suite.with(seed).as('bob').set(bob, userData).ok(done);
       });
 
+      it('should allow secret key to be added', (done) => {
+        seed.auth.users = {bob: userData};
+        suite.with(seed).as('bob', null, true).update(bob, {
+          secretKey: 's'.repeat(16),
+          secretKeyValidUntil: Date.now() + 3600
+        }).ok(done);
+      });
+
     });
 
   });

--- a/rules/auth.bolt
+++ b/rules/auth.bolt
@@ -44,6 +44,8 @@ type User {
   country: Country | Null,
   yearOfBirth: BirthYear | Null,  
   school: School | Null,
+  secretKey: SecretKey | Null,
+  secretKeyValidUntil: Time | Null,
 }
 
 type UserRef {

--- a/rules/shared.bolt
+++ b/rules/shared.bolt
@@ -39,6 +39,12 @@ type PublicId extends String {
   validate() = isPublicId(this);
 }
 
+type SecretKey extends String {
+  validate() = this.length >= 16;
+}
+
+type Time extends Number;
+
 type TimeStamp extends Number {
   validate() = this == now;
 }


### PR DESCRIPTION
A secret key is required for generate a code combat lookup link. Rules to allow it was missing.
